### PR TITLE
Added titles to mp3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,3 @@ sh chomikuj.sh "https://link-to-chomikuj-folder"
 ```
 > **Warning**
 > Remember that the script saves files in the current location, be careful not to clutter your folder
-
-
-## Inline usage
-```
-curl -s "LINK" | grep "fileActionsButtons clear visibleButtons  fileIdContainer" | awk -F 'rel="' '{print $2}' | awk -F '"' '{print $1}' | xargs -I{} wget "https://chomikuj.pl/Audio.ashx?id={}&type=2&tp=mp3" -O "{}.mp3"
-```
->  Only change this first curl LINK

--- a/chomikuj.sh
+++ b/chomikuj.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 [ -z "$1" ] && echo "No url" && exit;
-curl -s "$1" | grep "fileActionsButtons clear visibleButtons  fileIdContainer" | awk -F 'rel="' '{print $2}' | awk -F '"' '{print $1}' | xargs -I{} wget "https://chomikuj.pl/Audio.ashx?id={}&type=2&tp=mp3" -O "{}.mp3"
+curl -s "$1" | grep "expanderHeader downloadAction downloadContext.*\.mp3(audio)" | while read songData; do
+  fileIdContainer=$(echo $songData | grep -o "[0-9]*\.mp3(audio)" | sed 's/.mp3(audio)//')
+  title=$(echo $songData | awk -F 'title="' '{print $2}' | awk -F '"' '{print $1}' | sed 's/ /\ /g')
+  wget "https://chomikuj.pl/Audio.ashx?id=$fileIdContainer&type=2&tp=mp3" -O "$title.mp3"
+done


### PR DESCRIPTION
As in the title.

Deleted "Inline usage" part from README.md due to it doesn't work (tested on Ubuntu 22.04 and MacOS Ventura).